### PR TITLE
fixed sensors for dashboard + fast polling

### DIFF
--- a/custom_components/eo_mini/__init__.py
+++ b/custom_components/eo_mini/__init__.py
@@ -24,7 +24,7 @@ from .const import (
     STARTUP_MESSAGE,
 )
 
-SCAN_INTERVAL = timedelta(minutes=30)
+SCAN_INTERVAL = timedelta(minutes=1)
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 

--- a/custom_components/eo_mini/sensor.py
+++ b/custom_components/eo_mini/sensor.py
@@ -38,7 +38,7 @@ class EOMiniChargerSessionEnergySensor(EOMiniChargerEntity, SensorEntity):
             key=SensorDeviceClass.ENERGY,
             native_unit_of_measurement=ENERGY_WATT_HOUR,
             device_class=SensorDeviceClass.ENERGY,
-            state_class=SensorStateClass.TOTAL,
+            state_class=SensorStateClass.TOTAL_INCREASING,
             name="Consumption",
         )
         super().__init__(*args)
@@ -47,15 +47,14 @@ class EOMiniChargerSessionEnergySensor(EOMiniChargerEntity, SensorEntity):
     def _handle_coordinator_update(self) -> None:
         "Handle updated data from the coordinator."
         if self.coordinator.data:
-            self._attr_last_reset = datetime.fromtimestamp(
-                self.coordinator.data["PiTime"]
-            )
-            # No idea why ESKWH is stored in KWh/s...
-            self._attr_native_value = self.coordinator.data["ESKWH"] / 3600
-        else:
-            self._attr_last_reset = None
-            self._attr_native_value = 0
-
+            if self.coordinator.data["ESKWH"] == 0:
+                self._attr_last_reset = datetime.fromtimestamp(
+                    self.coordinator.data["PiTime"]
+                )
+                self._attr_native_value = 0
+            else:
+                # No idea why ESKWH is stored in KWh/s...
+                self._attr_native_value = self.coordinator.data["ESKWH"] / 3600
         self.async_write_ha_state()
 
     @property
@@ -76,7 +75,7 @@ class EOMiniChargerSessionChargingTimeSensor(EOMiniChargerEntity, SensorEntity):
             key=SensorDeviceClass.DURATION,
             native_unit_of_measurement=TIME_SECONDS,
             device_class=SensorDeviceClass.DURATION,
-            state_class=SensorStateClass.TOTAL,
+            state_class=SensorStateClass.TOTAL_INCREASING,
             name="Charging Time",
         )
         self._attr_native_value = 0
@@ -87,15 +86,13 @@ class EOMiniChargerSessionChargingTimeSensor(EOMiniChargerEntity, SensorEntity):
         "Handle updated data from the coordinator."
 
         if self.coordinator.data:
-            self._attr_last_reset = datetime.fromtimestamp(
-                self.coordinator.data["PiTime"]
-            )
-
-            self._attr_native_value = self.coordinator.data["ChargingTime"]
-        else:
-            self._attr_last_reset = None
-            self._attr_native_value = 0
-
+            if self.coordinator.data["ESKWH"] == 0:
+                self._attr_last_reset = datetime.fromtimestamp(
+                    self.coordinator.data["PiTime"]
+                )
+                self._attr_native_value = 0
+            else:
+                self._attr_native_value = self.coordinator.data["ChargingTime"]
         self.async_write_ha_state()
 
     @property


### PR DESCRIPTION
Hello! Great work on this custom integration.

I have two initial suggested changes:

The first is simple - shortening the polling interval. From some testing, the EO seems perfectly capable of providing data once per minute and this helps with seeing what's happening, especially with short charges. Maybe long term, this could be a config item?

The second is more complex but more importantly, I have changed the sensor behavior in the following ways. These are all aimed at having the sensors behave in the expected ways in Home Assistant, particularly the Energy Dashboard:

- Changed the StateClass to be 'total_increasing' for both sensors. This is a match for the Home Assistant documentation on a sensor like this which increases then goes through a reset back to 0 periodically - from the documentation for 'total_increasing' : _"Similar to total, with the restriction that the state represents a monotonically increasing positive total which periodically restarts counting from 0, e.g. a daily amount of consumed gas, weekly water consumption or lifetime energy consumption."_ . The previous setting total is only suitable if the value decreasing has some sort of information e.g. a net energy meter. 

- Changed the logic for when 'last_reset' is registered, and when to record a 0 value. Previously the sensor reset every time it got a reading/data from the API. Instead, it should only reset when the value for the session drops back to 0 / it's a new session. This, combined with the StateClass drop it back to 0.

My apologies in advance that although I have a developer background, Python is new to me and I may have made some basic mistakes, hopefully, the principle of what I think the code should do is at least clear. I think there are quite a few error states to manage, which this does not yet do (like a potential race condition on never getting to 0, although the 1-minute scan interval in my testing seems to solve this).

To illustrate the outcome of these changes, this is how a charge session now registers in Home Assistant:
![image](https://user-images.githubusercontent.com/7305486/200958841-2e04cb1d-2459-4d8e-8cf4-46f0d5dfdfe4.png)

This compares to how one could look previously:
![image](https://user-images.githubusercontent.com/7305486/200958982-84ca7dae-1d89-4a98-acc2-f5dfd8a16ab0.png)

With these changes, data correctly accumulates on the energy dashboard too (still testing to validate this further):
![image](https://user-images.githubusercontent.com/7305486/200959200-4f08c489-88ef-41e1-8222-6ef390061f30.png)
