### PR TITLE
Charging options

### DIFF
--- a/custom_components/eo_mini/__init__.py
+++ b/custom_components/eo_mini/__init__.py
@@ -92,6 +92,7 @@ class EODataUpdateCoordinator(DataUpdateCoordinator):
         self.device = {}
         self.serial = ""
         self.model = ""
+        self.charge_options = {}
         self._user_data = None
         self._minis_list = None
 
@@ -105,8 +106,8 @@ class EODataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Update data via library."""
         try:
-            if not self._user_data:
-                self._user_data = await self.api.async_get_user()
+            self._user_data = await self.api.async_get_user()
+            self.charge_options = self._user_data["chargeOpts"]
 
             self._minis_list = await self.api.async_get_list()
             assert len(self._minis_list) == 1

--- a/custom_components/eo_mini/api.py
+++ b/custom_components/eo_mini/api.py
@@ -1,8 +1,10 @@
 "EO API Client."
 import logging
+from typing import Union
+import urllib
+
 import aiohttp
 import async_timeout
-import urllib
 
 TIMEOUT = 10
 
@@ -97,38 +99,18 @@ class EOApiClient:
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
 
-    async def async_charge_mode_disable(
-        self, mode: str, charge_options: dict
+    async def async_update_charge_options(
+        self, key: str, value: Union[str, int, float], charge_options: dict
     ) -> list[dict]:
-        "Disable the specified charge mode"
-        data = charge_options
-        data[mode] = 0
-        return await self._async_api_wrapper(
-            "post",
-            f"{self.base_url}/api/user/updateChargeOpts",
-            data=data,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-        )
+        """Update entry in the chargeOpts dictionary.
 
-    async def async_charge_mode_enable(
-        self, mode: str, charge_options: dict
-    ) -> list[dict]:
-        "Enable the specified charge mode"
+        Args:
+            key: The entry in the chargeOpts dictionary to update
+            value: The value to assign to the dictionary item
+            charge_options: The charge_options dictionary to update
+        """
         data = charge_options
-        data[mode] = 1
-        return await self._async_api_wrapper(
-            "post",
-            f"{self.base_url}/api/user/updateChargeOpts",
-            data=data,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-        )
-
-    async def async_solar_min_charge_current(
-        self, current: int, charge_options: dict
-    ) -> list[dict]:
-        "Set the solar minimum rate of charge"
-        data = charge_options
-        data["solarMin"] = current
+        data[key] = value
         return await self._async_api_wrapper(
             "post",
             f"{self.base_url}/api/user/updateChargeOpts",

--- a/custom_components/eo_mini/api.py
+++ b/custom_components/eo_mini/api.py
@@ -97,6 +97,45 @@ class EOApiClient:
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
 
+    async def async_charge_mode_disable(
+        self, mode: str, charge_options: dict
+    ) -> list[dict]:
+        "Disable the specified charge mode"
+        data = charge_options
+        data[mode] = 0
+        return await self._async_api_wrapper(
+            "post",
+            f"{self.base_url}/api/user/updateChargeOpts",
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+    async def async_charge_mode_enable(
+        self, mode: str, charge_options: dict
+    ) -> list[dict]:
+        "Enable the specified charge mode"
+        data = charge_options
+        data[mode] = 1
+        return await self._async_api_wrapper(
+            "post",
+            f"{self.base_url}/api/user/updateChargeOpts",
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+    async def async_solar_min_charge_current(
+        self, current: int, charge_options: dict
+    ) -> list[dict]:
+        "Set the solar minimum rate of charge"
+        data = charge_options
+        data["solarMin"] = current
+        return await self._async_api_wrapper(
+            "post",
+            f"{self.base_url}/api/user/updateChargeOpts",
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
     async def _async_api_wrapper(
         self, method: str, url: str, _reissue=False, **kwargs
     ) -> dict:

--- a/custom_components/eo_mini/const.py
+++ b/custom_components/eo_mini/const.py
@@ -8,9 +8,10 @@ ATTRIBUTION = "Data provided by EO"
 ISSUE_URL = "https://github.com/twhittock/eo_mini/issues"
 
 # Platforms
+NUMBER = "number"
 SENSOR = "sensor"
 SWITCH = "switch"
-PLATFORMS = [SENSOR, SWITCH]
+PLATFORMS = [NUMBER, SENSOR, SWITCH]
 
 
 # Configuration and options

--- a/custom_components/eo_mini/number.py
+++ b/custom_components/eo_mini/number.py
@@ -25,18 +25,19 @@ async def async_setup_entry(hass, entry, async_add_devices):
 
 class EOMiniSolarMinCurrent(EOMiniChargerEntity, NumberEntity):
     """Number entity to represent the solar minimum rate of charge."""
+
     coordinator: EODataUpdateCoordinator
 
     def __init__(self, *args):
         self.entity_description = NumberEntityDescription(
-            key = "Minimum_charge_current",
-            name = "Minimum charge current",
-            native_step = 1,
-            native_min_value = 6,
-            native_max_value = 32,
-            native_unit_of_measurement = UnitOfElectricCurrent.AMPERE,
-            device_class = NumberDeviceClass.CURRENT,
-            icon = "mdi:current-ac",
+            key="Minimum_charge_current",
+            name="Minimum charge current",
+            native_step=1,
+            native_min_value=6,
+            native_max_value=32,
+            native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+            device_class=NumberDeviceClass.CURRENT,
+            icon="mdi:current-ac",
         )
         super().__init__(*args)
         self._attr_mode = NumberMode.BOX
@@ -47,7 +48,6 @@ class EOMiniSolarMinCurrent(EOMiniChargerEntity, NumberEntity):
         if self.coordinator.charge_options:
             self._attr_native_value = int(self.coordinator.charge_options["solarMin"])
         self.async_write_ha_state()
-
 
     async def async_set_native_value(self, value: float) -> None:
         """Set new minimum solar charge current value."""

--- a/custom_components/eo_mini/number.py
+++ b/custom_components/eo_mini/number.py
@@ -1,0 +1,62 @@
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.const import UnitOfElectricCurrent
+from homeassistant.core import callback
+
+from custom_components.eo_mini import EODataUpdateCoordinator
+
+from .const import DOMAIN
+from .entity import EOMiniChargerEntity
+
+
+async def async_setup_entry(hass, entry, async_add_devices):
+    """Setup number platform."""
+    coordinator: EODataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_devices(
+        [
+            EOMiniSolarMinCurrent(coordinator),
+        ]
+    )
+
+
+class EOMiniSolarMinCurrent(EOMiniChargerEntity, NumberEntity):
+    """Number entity to represent the solar minimum rate of charge."""
+    coordinator: EODataUpdateCoordinator
+
+    def __init__(self, *args):
+        self.entity_description = NumberEntityDescription(
+            key = "Minimum_charge_current",
+            name = "Minimum charge current",
+            native_step = 1,
+            native_min_value = 6,
+            native_max_value = 32,
+            native_unit_of_measurement = UnitOfElectricCurrent.AMPERE,
+            device_class = NumberDeviceClass.CURRENT,
+            icon = "mdi:current-ac",
+        )
+        super().__init__(*args)
+        self._attr_mode = NumberMode.BOX
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if self.coordinator.charge_options:
+            self._attr_native_value = int(self.coordinator.charge_options["solarMin"])
+        self.async_write_ha_state()
+
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set new minimum solar charge current value."""
+        await self.coordinator.api.async_solar_min_charge_current(
+            int(value), self.coordinator.charge_options
+        )
+        await self.coordinator.async_refresh()
+
+    @property
+    def unique_id(self):
+        "Return a unique ID to use for this entity."
+        return f"{DOMAIN}_charger_{self.coordinator.serial}_solar_min_charge"

--- a/custom_components/eo_mini/number.py
+++ b/custom_components/eo_mini/number.py
@@ -51,8 +51,8 @@ class EOMiniSolarMinCurrent(EOMiniChargerEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set new minimum solar charge current value."""
-        await self.coordinator.api.async_solar_min_charge_current(
-            int(value), self.coordinator.charge_options
+        await self.coordinator.api.async_update_charge_options(
+            "solarMin", int(value), self.coordinator.charge_options
         )
         await self.coordinator.async_refresh()
 

--- a/custom_components/eo_mini/switch.py
+++ b/custom_components/eo_mini/switch.py
@@ -100,16 +100,16 @@ class EOMiniOffPeakSwitch(EOMiniChargerEntity, SwitchEntity):
         self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs):
-        await self.coordinator.api.async_charge_mode_enable(
-            "opMode", self.coordinator.charge_options
+        await self.coordinator.api.async_update_charge_options(
+            "opMode", 1, self.coordinator.charge_options
         )
 
         # Get the state back from the API
         await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs):
-        await self.coordinator.api.async_charge_mode_disable(
-            "opMode", self.coordinator.charge_options
+        await self.coordinator.api.async_update_charge_options(
+            "opMode", 0, self.coordinator.charge_options
         )
 
         # Get the state back from the API
@@ -147,16 +147,16 @@ class EOMiniSolarSwitch(EOMiniChargerEntity, SwitchEntity):
         self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs):
-        await self.coordinator.api.async_charge_mode_enable(
-            "solarMode", self.coordinator.charge_options
+        await self.coordinator.api.async_update_charge_options(
+            "solarMode", 1, self.coordinator.charge_options
         )
 
         # Get the state back from the API
         await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs):
-        await self.coordinator.api.async_charge_mode_disable(
-            "solarMode", self.coordinator.charge_options
+        await self.coordinator.api.async_update_charge_options(
+            "solarMode", 0, self.coordinator.charge_options
         )
 
         # Get the state back from the API
@@ -194,16 +194,16 @@ class EOMiniScheduledSwitch(EOMiniChargerEntity, SwitchEntity):
         self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs):
-        await self.coordinator.api.async_charge_mode_enable(
-            "timeMode", self.coordinator.charge_options
+        await self.coordinator.api.async_update_charge_options(
+            "timeMode", 1, self.coordinator.charge_options
         )
 
         # Get the state back from the API
         await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs):
-        await self.coordinator.api.async_charge_mode_disable(
-            "timeMode", self.coordinator.charge_options
+        await self.coordinator.api.async_update_charge_options(
+            "timeMode", 0, self.coordinator.charge_options
         )
 
         # Get the state back from the API

--- a/custom_components/eo_mini/switch.py
+++ b/custom_components/eo_mini/switch.py
@@ -101,8 +101,7 @@ class EOMiniOffPeakSwitch(EOMiniChargerEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs):
         await self.coordinator.api.async_charge_mode_enable(
-            "opMode",
-            self.coordinator.charge_options
+            "opMode", self.coordinator.charge_options
         )
 
         # Get the state back from the API
@@ -110,8 +109,7 @@ class EOMiniOffPeakSwitch(EOMiniChargerEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs):
         await self.coordinator.api.async_charge_mode_disable(
-            "opMode",
-            self.coordinator.charge_options
+            "opMode", self.coordinator.charge_options
         )
 
         # Get the state back from the API
@@ -150,8 +148,7 @@ class EOMiniSolarSwitch(EOMiniChargerEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs):
         await self.coordinator.api.async_charge_mode_enable(
-            "solarMode",
-            self.coordinator.charge_options
+            "solarMode", self.coordinator.charge_options
         )
 
         # Get the state back from the API
@@ -159,8 +156,7 @@ class EOMiniSolarSwitch(EOMiniChargerEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs):
         await self.coordinator.api.async_charge_mode_disable(
-            "solarMode",
-            self.coordinator.charge_options
+            "solarMode", self.coordinator.charge_options
         )
 
         # Get the state back from the API
@@ -199,8 +195,7 @@ class EOMiniScheduledSwitch(EOMiniChargerEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs):
         await self.coordinator.api.async_charge_mode_enable(
-            "timeMode",
-            self.coordinator.charge_options
+            "timeMode", self.coordinator.charge_options
         )
 
         # Get the state back from the API
@@ -208,8 +203,7 @@ class EOMiniScheduledSwitch(EOMiniChargerEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs):
         await self.coordinator.api.async_charge_mode_disable(
-            "timeMode",
-            self.coordinator.charge_options
+            "timeMode", self.coordinator.charge_options
         )
 
         # Get the state back from the API


### PR DESCRIPTION
Adds charge options to turn on/off Off-Peak / Solar / Scheduled Charging.
Also adds a number entity for the minimum current for solar charging.

These seem to work ok with my setup. I could turn the charge modes off/on and change the minimum charge limit and that was reflected in the EO Smart Home App.

There is probably one caveat around having a time schedule defined for the things being turned on already via the app. Ideally I would have liked to have added entities to cover the start/stop times for the three different charge types. But I think it would be best to do this with a [time entity](https://developers.home-assistant.io/docs/core/entity/time) and looking at the [PR](https://github.com/home-assistant/core/pull/81949) that added that, it looks like that may be coming later in 2023.6